### PR TITLE
fix: 5 bugs — sidebar scroll, Quit command, UTF-8 cursor, indent gutter, tick leak

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -999,6 +999,8 @@ func (m *Model) execCommand(name string) tea.Cmd {
 	case "Close Pane":
 		m.panes.ClosePane()
 		m.recalcLayout()
+	case "Quit":
+		return tea.Quit
 	case "AI: kiro-cli", "AI: claude", "AI: codex", "AI: shell (plain terminal)":
 		provider := strings.TrimPrefix(name, "AI: ")
 		if provider == "shell (plain terminal)" {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Test 7: "Quit" in the command palette actually returns tea.Quit.
+func TestExecCommandQuit(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	cmd := m.execCommand("Quit")
+	if cmd == nil {
+		t.Fatal("execCommand(\"Quit\") returned nil, want tea.Quit cmd")
+	}
+	// Execute the cmd to get the message it produces.
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Errorf("execCommand(\"Quit\") produced %T, want tea.QuitMsg", msg)
+	}
+}

--- a/editor/buffer.go
+++ b/editor/buffer.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 type Position struct {
@@ -140,7 +141,9 @@ func (b *Buffer) Backspace() {
 	}
 	var delStart Position
 	if b.Cursor.Col > 0 {
-		delStart = Position{Line: b.Cursor.Line, Col: b.Cursor.Col - 1}
+		line := b.Lines[b.Cursor.Line]
+		_, runeSize := utf8.DecodeLastRuneInString(line[:b.Cursor.Col])
+		delStart = Position{Line: b.Cursor.Line, Col: b.Cursor.Col - runeSize}
 	} else {
 		delStart = Position{Line: b.Cursor.Line - 1, Col: len(b.Lines[b.Cursor.Line-1])}
 	}
@@ -201,7 +204,8 @@ func (b *Buffer) CursorDown() {
 
 func (b *Buffer) CursorLeft() {
 	if b.Cursor.Col > 0 {
-		b.Cursor.Col--
+		_, size := utf8.DecodeLastRuneInString(b.Lines[b.Cursor.Line][:b.Cursor.Col])
+		b.Cursor.Col -= size
 	} else if b.Cursor.Line > 0 {
 		b.Cursor.Line--
 		b.Cursor.Col = len(b.Lines[b.Cursor.Line])
@@ -209,8 +213,10 @@ func (b *Buffer) CursorLeft() {
 }
 
 func (b *Buffer) CursorRight() {
-	if b.Cursor.Col < len(b.Lines[b.Cursor.Line]) {
-		b.Cursor.Col++
+	line := b.Lines[b.Cursor.Line]
+	if b.Cursor.Col < len(line) {
+		_, size := utf8.DecodeRuneInString(line[b.Cursor.Col:])
+		b.Cursor.Col += size
 	} else if b.Cursor.Line < len(b.Lines)-1 {
 		b.Cursor.Line++
 		b.Cursor.Col = 0
@@ -236,12 +242,20 @@ func (b *Buffer) CursorWordLeft() {
 	line := b.Lines[b.Cursor.Line]
 	col := b.Cursor.Col
 	// Skip whitespace/punctuation backwards
-	for col > 0 && !isWordChar(rune(line[col-1])) {
-		col--
+	for col > 0 {
+		r, size := utf8.DecodeLastRuneInString(line[:col])
+		if isWordChar(r) {
+			break
+		}
+		col -= size
 	}
 	// Skip word chars backwards
-	for col > 0 && isWordChar(rune(line[col-1])) {
-		col--
+	for col > 0 {
+		r, size := utf8.DecodeLastRuneInString(line[:col])
+		if !isWordChar(r) {
+			break
+		}
+		col -= size
 	}
 	b.Cursor.Col = col
 }
@@ -257,12 +271,20 @@ func (b *Buffer) CursorWordRight() {
 	}
 	col := b.Cursor.Col
 	// Skip word chars forward
-	for col < len(line) && isWordChar(rune(line[col])) {
-		col++
+	for col < len(line) {
+		r, size := utf8.DecodeRuneInString(line[col:])
+		if !isWordChar(r) {
+			break
+		}
+		col += size
 	}
 	// Skip whitespace/punctuation forward
-	for col < len(line) && !isWordChar(rune(line[col])) {
-		col++
+	for col < len(line) {
+		r, size := utf8.DecodeRuneInString(line[col:])
+		if isWordChar(r) {
+			break
+		}
+		col += size
 	}
 	b.Cursor.Col = col
 }

--- a/editor/buffer_test.go
+++ b/editor/buffer_test.go
@@ -1,0 +1,71 @@
+package editor
+
+import "testing"
+
+// Test 1: Backspace on multi-byte UTF-8 rune deletes the whole rune, not just one byte.
+func TestBackspaceUTF8(t *testing.T) {
+	b := NewBufferFromString("héllo")
+	// Move cursor to after é (byte col 3: h=1, é=2 bytes)
+	b.Cursor.Col = 3
+	b.Backspace()
+	if b.Lines[0] != "hllo" {
+		t.Errorf("Backspace on é: got %q, want %q", b.Lines[0], "hllo")
+	}
+	if b.Cursor.Col != 1 {
+		t.Errorf("Cursor col after Backspace: got %d, want 1", b.Cursor.Col)
+	}
+}
+
+// Test 2: CursorLeft on multi-byte rune steps back a full rune.
+func TestCursorLeftUTF8(t *testing.T) {
+	b := NewBufferFromString("héllo")
+	b.Cursor.Col = 3 // after é
+	b.CursorLeft()
+	if b.Cursor.Col != 1 {
+		t.Errorf("CursorLeft on é: col got %d, want 1", b.Cursor.Col)
+	}
+}
+
+// Test 3: CursorRight on multi-byte rune steps forward a full rune.
+func TestCursorRightUTF8(t *testing.T) {
+	b := NewBufferFromString("héllo")
+	b.Cursor.Col = 1 // on é
+	b.CursorRight()
+	if b.Cursor.Col != 3 {
+		t.Errorf("CursorRight on é: col got %d, want 3", b.Cursor.Col)
+	}
+}
+
+// Test 4: CursorWordLeft with multi-byte chars doesn't panic or split rune.
+func TestCursorWordLeftUTF8(t *testing.T) {
+	b := NewBufferFromString("héllo wörld")
+	b.Cursor.Col = len("héllo wörld")
+	b.CursorWordLeft() // should land at start of wörld
+	// "héllo " is 8 bytes (h=1, é=2, l=1, l=1, o=1, space=1 → 7), wait: h(1)+é(2)+l+l+o+space = 7
+	want := len("héllo ")
+	if b.Cursor.Col != want {
+		t.Errorf("CursorWordLeft: col got %d, want %d", b.Cursor.Col, want)
+	}
+}
+
+// Test 5: indentSelection bumps EditVersion so BufferChangedMsg fires.
+func TestIndentSelectionBumpsVersion(t *testing.T) {
+	m := NewModel()
+	_ = m.OpenFile("")
+	// The model has an empty buffer. Set some content directly.
+	m.tabs[0].buf.Lines = []string{"    hello", "    world"}
+	m.tabs[0].buf.Selection = Selection{
+		Anchor: Position{Line: 0, Col: 0},
+		Head:   Position{Line: 1, Col: 0},
+		Active: true,
+	}
+	before := m.tabs[0].buf.EditVersion
+	m.indentSelection(-1) // dedent
+	after := m.tabs[0].buf.EditVersion
+	if after == before {
+		t.Errorf("indentSelection did not bump EditVersion: before=%d after=%d", before, after)
+	}
+	if m.tabs[0].buf.Lines[0] != "hello" {
+		t.Errorf("dedent line 0: got %q, want %q", m.tabs[0].buf.Lines[0], "hello")
+	}
+}

--- a/editor/view.go
+++ b/editor/view.go
@@ -555,6 +555,7 @@ func (m *Model) indentSelection(dir int) {
 		}
 	}
 	t.buf.Dirty = true
+	t.buf.EditVersion++
 }
 
 func (m *Model) ensureVisible() {

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -218,14 +218,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if len(m.tabs) > 0 && m.scrollY == 0 {
 			m.captureHistory()
 		}
-		anyAlive := false
-		for _, t := range m.tabs {
-			if !t.done.Load() {
-				anyAlive = true
-				break
-			}
-		}
-		if !anyAlive && len(m.tabs) == 0 {
+		if len(m.tabs) == 0 {
 			m.ticking = false
 			return m, nil
 		}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -179,9 +179,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if maxScroll < 0 {
 			maxScroll = 0
 		}
-		if msg.Y < 0 && m.scroll > 0 {
+		if msg.Button == tea.MouseWheelUp && m.scroll > 0 {
 			m.scroll--
-		} else if msg.Y > 0 && m.scroll < maxScroll {
+		} else if msg.Button == tea.MouseWheelDown && m.scroll < maxScroll {
 			m.scroll++
 		}
 	}

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Test 6: Sidebar mouse wheel scroll uses msg.Button, not msg.Y.
+// Before the fix, msg.Y < 0 was the condition — but Y is a screen coordinate
+// so it's always >= 0 and scroll never worked.
+func TestSidebarMouseWheelScroll(t *testing.T) {
+	m := New("/home/nishchay/grotto")
+	// Force a long enough tree and a non-zero height so scrolling is possible.
+	m.height = 3 // small window so even a few items overflow
+
+	// Scroll down
+	before := m.scroll
+	m, _ = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if m.scroll <= before && len(m.flat) > m.height {
+		t.Errorf("scroll down: scroll stayed at %d (was %d), tree has %d items, height %d",
+			m.scroll, before, len(m.flat), m.height)
+	}
+
+	// Scroll back up
+	m, _ = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if m.scroll != before {
+		t.Errorf("scroll up: scroll got %d, want %d", m.scroll, before)
+	}
+}


### PR DESCRIPTION
## Summary

- **Sidebar mouse wheel scroll broken** (`ui/sidebar.go`) — compared `msg.Y` (screen Y coordinate, always ≥ 0) instead of `msg.Button` to detect wheel direction; scroll never triggered
- **"Quit" in command palette did nothing** (`app/app.go`) — listed in `commandNames()` but had no `case` in `execCommand()`
- **UTF-8 cursor/edit corruption** (`editor/buffer.go`) — `CursorLeft`, `CursorRight`, `Backspace`, `CursorWordLeft`, `CursorWordRight` all stepped by byte instead of rune; multi-byte chars (é, 中, emoji) were split or garbled; fixed with `utf8.DecodeRuneInString` / `utf8.DecodeLastRuneInString`
- **Tab/Shift+Tab didn't trigger git gutter update** (`editor/view.go`) — `indentSelection` set `Dirty=true` but never bumped `EditVersion`, so `BufferChangedMsg` was never emitted after indent/dedent
- **Terminal tick-loop CPU waste** (`terminal/terminal.go`) — stop condition `!anyAlive && len(tabs)==0` is equivalent to `len(tabs)==0`; removed dead `anyAlive` loop

## Test plan

- [x] 7 unit tests added (`editor/buffer_test.go`, `ui/sidebar_test.go`, `app/app_test.go`) — all pass
- [x] Sidebar scroll verified live via wezterm CLI automation (before/after top-line changed on wheel-up)
- [x] "Quit" via command palette verified live — grotto process exited cleanly
- [x] UTF-8 backspace verified live — typing `héllo`, backspacing over `é` left `hllo` not a garbled byte
- [x] `TestSidebarMouseWheelScroll` confirmed to **fail** against the old `msg.Y` code (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)