### PR TITLE
feat: confirm dialog for unsaved changes on quit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -79,6 +79,7 @@ type Model struct {
 	terminal terminal.Model
 	aiPanel  terminal.Model
 	overlay  Overlay
+	confirm  ConfirmDialog
 
 	// View cache — skip re-rendering unchanged panels
 	cachedSidebar  string
@@ -280,6 +281,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.waitForGitChange()
 
 	case tea.KeyPressMsg:
+		// Confirm dialog takes precedence over every other handler.
+		if m.confirm.Active() {
+			consumed, action := m.confirm.Update(msg)
+			if consumed {
+				if action != ConfirmPending {
+					return m.handleConfirmAction(action)
+				}
+				return m, nil
+			}
+		}
+
 		// Overlay intercepts all input when active
 		if m.overlay.Active() {
 			mode := m.overlay.mode
@@ -314,6 +326,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.String() {
 		case "ctrl+q":
+			if paths := dirtyPaths(m.panes.DirtyBuffers()); len(paths) > 0 {
+				m.confirm.Open(ConfirmReasonQuit, paths)
+				return m, nil
+			}
 			return m, tea.Quit
 		case "f5":
 			m.overlay.OpenShortcuts()
@@ -925,6 +941,21 @@ func (m Model) View() tea.View {
 		full = strings.Join(lines, "\n")
 	}
 
+	// Confirm dialog floats above everything else.
+	if m.confirm.Active() {
+		dialogView := m.confirm.View(m.width, m.height)
+		lines := strings.Split(full, "\n")
+		dialogLines := strings.Split(dialogView, "\n")
+		insertAt := 2
+		for i, dl := range dialogLines {
+			pos := insertAt + i
+			if pos < len(lines) {
+				lines[pos] = dl
+			}
+		}
+		full = strings.Join(lines, "\n")
+	}
+
 	v.Content = full
 	return v
 }
@@ -1000,6 +1031,10 @@ func (m *Model) execCommand(name string) tea.Cmd {
 		m.panes.ClosePane()
 		m.recalcLayout()
 	case "Quit":
+		if paths := dirtyPaths(m.panes.DirtyBuffers()); len(paths) > 0 {
+			m.confirm.Open(ConfirmReasonQuit, paths)
+			return nil
+		}
 		return tea.Quit
 	case "AI: kiro-cli", "AI: claude", "AI: codex", "AI: shell (plain terminal)":
 		provider := strings.TrimPrefix(name, "AI: ")
@@ -1014,4 +1049,39 @@ func (m *Model) execCommand(name string) tea.Cmd {
 		return m.aiPanel.AddTermWithCmd(provider, m.aiCommand())
 	}
 	return nil
+}
+
+// dirtyPaths returns the file paths for a list of dirty buffers. Used to
+// populate the confirm dialog's file list.
+func dirtyPaths(bufs []*editor.Buffer) []string {
+	out := make([]string, 0, len(bufs))
+	for _, b := range bufs {
+		out = append(out, b.FilePath)
+	}
+	return out
+}
+
+// handleConfirmAction completes the action that was gated by the confirm dialog.
+// Returns updated model and any Cmd.
+func (m Model) handleConfirmAction(action ConfirmAction) (tea.Model, tea.Cmd) {
+	reason := m.confirm.Reason()
+	m.confirm.Close()
+
+	if action == ConfirmCancel {
+		return m, nil
+	}
+	if action == ConfirmSave {
+		if err := m.panes.SaveAllDirty(); err != nil {
+			// Keep the dialog closed but abort the destructive action so the
+			// user can investigate. A future iteration could surface the error.
+			return m, nil
+		}
+	}
+	// ConfirmDiscard falls through without saving.
+
+	switch reason {
+	case ConfirmReasonQuit:
+		return m, tea.Quit
+	}
+	return m, nil
 }

--- a/app/confirm.go
+++ b/app/confirm.go
@@ -1,0 +1,124 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// ConfirmAction is the user's choice on a confirm dialog.
+type ConfirmAction int
+
+const (
+	ConfirmPending ConfirmAction = iota
+	ConfirmSave
+	ConfirmDiscard
+	ConfirmCancel
+)
+
+// ConfirmReason identifies which caller raised the dialog so the app can
+// route the post-confirmation action correctly.
+type ConfirmReason int
+
+const (
+	ConfirmReasonNone ConfirmReason = iota
+	ConfirmReasonQuit
+	ConfirmReasonCloseTab
+)
+
+// ConfirmDialog is a modal asking the user what to do about unsaved files
+// before a destructive action (quit, close tab).
+type ConfirmDialog struct {
+	active bool
+	reason ConfirmReason
+	files  []string // display names of dirty files
+}
+
+func (d *ConfirmDialog) Active() bool      { return d.active }
+func (d *ConfirmDialog) Reason() ConfirmReason { return d.reason }
+
+// Open shows the dialog with the list of dirty file paths.
+func (d *ConfirmDialog) Open(reason ConfirmReason, dirtyPaths []string) {
+	d.active = true
+	d.reason = reason
+	d.files = make([]string, len(dirtyPaths))
+	for i, p := range dirtyPaths {
+		if p == "" {
+			d.files[i] = "(untitled)"
+		} else {
+			d.files[i] = filepath.Base(p)
+		}
+	}
+}
+
+func (d *ConfirmDialog) Close() {
+	d.active = false
+	d.reason = ConfirmReasonNone
+	d.files = nil
+}
+
+// Update processes a key press. Returns (consumed, action). `action` is
+// ConfirmPending while the dialog is waiting for input.
+func (d *ConfirmDialog) Update(msg tea.Msg) (bool, ConfirmAction) {
+	if !d.active {
+		return false, ConfirmPending
+	}
+	km, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return false, ConfirmPending
+	}
+	switch km.String() {
+	case "s", "S":
+		return true, ConfirmSave
+	case "d", "D":
+		return true, ConfirmDiscard
+	case "c", "C", "esc":
+		return true, ConfirmCancel
+	case "enter":
+		// Enter defaults to Save — the least destructive option.
+		return true, ConfirmSave
+	}
+	return true, ConfirmPending // consume other keys while modal is up
+}
+
+// View renders the dialog centered horizontally at the top of the content area.
+func (d *ConfirmDialog) View(width, height int) string {
+	if !d.active {
+		return ""
+	}
+
+	title := "Unsaved changes"
+	switch d.reason {
+	case ConfirmReasonQuit:
+		title = "Unsaved changes — quit?"
+	case ConfirmReasonCloseTab:
+		title = "Unsaved changes — close tab?"
+	}
+
+	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFB86C")).Bold(true)
+	fileStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2"))
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#BD93F9")).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4"))
+
+	var lines []string
+	lines = append(lines, titleStyle.Render(title))
+	lines = append(lines, "")
+	for _, f := range d.files {
+		lines = append(lines, "  • "+fileStyle.Render(f))
+	}
+	lines = append(lines, "")
+	lines = append(lines,
+		keyStyle.Render("[S]")+dimStyle.Render("ave  ")+
+			keyStyle.Render("[D]")+dimStyle.Render("iscard  ")+
+			keyStyle.Render("[C]")+dimStyle.Render("ancel / Esc"))
+
+	content := strings.Join(lines, "\n")
+
+	boxW := min(width-4, 50)
+	box := overlayBoxStyle.Width(boxW).Render(content)
+
+	pad := max((width-boxW-2)/2, 0)
+	return strings.Repeat(" ", pad) + box
+}

--- a/app/confirm.go
+++ b/app/confirm.go
@@ -36,7 +36,7 @@ type ConfirmDialog struct {
 	files  []string // display names of dirty files
 }
 
-func (d *ConfirmDialog) Active() bool      { return d.active }
+func (d *ConfirmDialog) Active() bool          { return d.active }
 func (d *ConfirmDialog) Reason() ConfirmReason { return d.reason }
 
 // Open shows the dialog with the list of dirty file paths.

--- a/app/confirm_test.go
+++ b/app/confirm_test.go
@@ -244,7 +244,7 @@ func mustWriteTemp(t *testing.T, content string) string {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatalf("WriteString: %v", err)
 	}

--- a/app/confirm_test.go
+++ b/app/confirm_test.go
@@ -1,0 +1,271 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ConfirmDialog unit tests — the dialog itself, independent of the app.
+
+func TestConfirmDialog_OpensAndCloses(t *testing.T) {
+	var d ConfirmDialog
+	if d.Active() {
+		t.Fatal("dialog active before Open()")
+	}
+	d.Open(ConfirmReasonQuit, []string{"a.go"})
+	if !d.Active() {
+		t.Fatal("dialog not active after Open()")
+	}
+	if d.Reason() != ConfirmReasonQuit {
+		t.Errorf("reason: got %v, want ConfirmReasonQuit", d.Reason())
+	}
+	d.Close()
+	if d.Active() {
+		t.Fatal("dialog still active after Close()")
+	}
+}
+
+func TestConfirmDialog_KeyActions(t *testing.T) {
+	cases := []struct {
+		key  string
+		want ConfirmAction
+	}{
+		{"s", ConfirmSave},
+		{"S", ConfirmSave},
+		{"enter", ConfirmSave}, // Enter defaults to Save
+		{"d", ConfirmDiscard},
+		{"D", ConfirmDiscard},
+		{"c", ConfirmCancel},
+		{"C", ConfirmCancel},
+		{"esc", ConfirmCancel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			var d ConfirmDialog
+			d.Open(ConfirmReasonQuit, []string{"a.go"})
+			consumed, action := d.Update(keyFromString(tc.key))
+			if !consumed {
+				t.Fatalf("key %q was not consumed", tc.key)
+			}
+			if action != tc.want {
+				t.Errorf("key %q: got action %v, want %v", tc.key, action, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfirmDialog_IgnoresInputWhenInactive(t *testing.T) {
+	var d ConfirmDialog
+	consumed, action := d.Update(keyFromString("s"))
+	if consumed {
+		t.Error("inactive dialog consumed input")
+	}
+	if action != ConfirmPending {
+		t.Errorf("inactive dialog returned action %v, want ConfirmPending", action)
+	}
+}
+
+func TestConfirmDialog_OtherKeysAreSwallowed(t *testing.T) {
+	// While the modal is up, unrelated keys must be consumed (to prevent them
+	// from reaching the editor) but must not resolve the dialog.
+	var d ConfirmDialog
+	d.Open(ConfirmReasonQuit, []string{"a.go"})
+	consumed, action := d.Update(keyFromString("x"))
+	if !consumed {
+		t.Error("random key should be consumed while modal is active")
+	}
+	if action != ConfirmPending {
+		t.Errorf("random key resolved dialog with action %v", action)
+	}
+	if !d.Active() {
+		t.Error("dialog closed itself on unrelated key")
+	}
+}
+
+// ---- App integration tests ----
+
+// Ctrl+Q on a clean editor quits immediately (no dialog).
+func TestCtrlQ_CleanEditor_Quits(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	updated, cmd := m.Update(keyFromString("ctrl+q"))
+	if _, ok := updated.(Model); !ok {
+		t.Fatalf("Update returned %T, want Model", updated)
+	}
+	if cmd == nil {
+		t.Fatal("Ctrl+Q with no dirty buffers should return tea.Quit, got nil")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Errorf("Ctrl+Q with clean editor: cmd produced non-QuitMsg")
+	}
+}
+
+// Ctrl+Q with a dirty buffer opens the dialog instead of quitting.
+func TestCtrlQ_DirtyBuffer_OpensDialog(t *testing.T) {
+	tmp := mustWriteTemp(t, "hello\n")
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	if err := m.panes.OpenFile(tmp); err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	// Mark the buffer dirty by mutating it.
+	m.panes.Buf().InsertChar('x')
+
+	updated, cmd := m.Update(keyFromString("ctrl+q"))
+	mm, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", updated)
+	}
+	if cmd != nil {
+		// Dialog opened → no Cmd should be returned (certainly not tea.Quit).
+		if msg := cmd(); msg != nil {
+			if _, isQuit := msg.(tea.QuitMsg); isQuit {
+				t.Fatal("Ctrl+Q with dirty buffer quit instead of showing dialog")
+			}
+		}
+	}
+	if !mm.confirm.Active() {
+		t.Error("Ctrl+Q with dirty buffer did not activate confirm dialog")
+	}
+	if mm.confirm.Reason() != ConfirmReasonQuit {
+		t.Errorf("dialog reason: got %v, want ConfirmReasonQuit", mm.confirm.Reason())
+	}
+}
+
+// Pressing Discard in the dialog issues a Quit.
+func TestConfirmDialog_DiscardQuits(t *testing.T) {
+	tmp := mustWriteTemp(t, "hello\n")
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	_ = m.panes.OpenFile(tmp)
+	m.panes.Buf().InsertChar('x')
+
+	// Open dialog via Ctrl+Q
+	updated, _ := m.Update(keyFromString("ctrl+q"))
+	m = updated.(Model)
+
+	// Press 'd' to discard.
+	updated, cmd := m.Update(keyFromString("d"))
+	m = updated.(Model)
+	if m.confirm.Active() {
+		t.Error("dialog still active after Discard")
+	}
+	if cmd == nil {
+		t.Fatal("Discard should return tea.Quit cmd")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Error("Discard: cmd did not produce QuitMsg")
+	}
+
+	// The buffer should still be dirty — discard does NOT save.
+	if !m.panes.Buf().Dirty {
+		t.Error("Discard saved the buffer (should have left it dirty)")
+	}
+}
+
+// Pressing Save in the dialog persists the file and then issues Quit.
+func TestConfirmDialog_SaveThenQuits(t *testing.T) {
+	tmp := mustWriteTemp(t, "hello\n")
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	_ = m.panes.OpenFile(tmp)
+	m.panes.Buf().InsertChar('x')
+
+	updated, _ := m.Update(keyFromString("ctrl+q"))
+	m = updated.(Model)
+
+	updated, cmd := m.Update(keyFromString("s"))
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("Save should return tea.Quit cmd")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Error("Save: cmd did not produce QuitMsg")
+	}
+	if m.panes.Buf().Dirty {
+		t.Error("Save did not clear dirty flag on buffer")
+	}
+	// And the file on disk should contain the edit.
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "xhello\n" {
+		t.Errorf("file content: got %q, want %q", string(data), "xhello\n")
+	}
+}
+
+// Pressing Cancel closes the dialog and does NOT quit.
+func TestConfirmDialog_CancelDoesNotQuit(t *testing.T) {
+	tmp := mustWriteTemp(t, "hello\n")
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	_ = m.panes.OpenFile(tmp)
+	m.panes.Buf().InsertChar('x')
+
+	updated, _ := m.Update(keyFromString("ctrl+q"))
+	m = updated.(Model)
+
+	updated, cmd := m.Update(keyFromString("esc"))
+	m = updated.(Model)
+	if m.confirm.Active() {
+		t.Error("dialog still active after Cancel")
+	}
+	if cmd != nil {
+		if _, ok := cmd().(tea.QuitMsg); ok {
+			t.Error("Cancel should not quit")
+		}
+	}
+	if !m.panes.Buf().Dirty {
+		t.Error("Cancel should leave the buffer dirty")
+	}
+}
+
+// Command palette "Quit" with dirty buffers opens dialog, does not quit.
+func TestExecCommandQuit_DirtyOpensDialog(t *testing.T) {
+	tmp := mustWriteTemp(t, "hello\n")
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	_ = m.panes.OpenFile(tmp)
+	m.panes.Buf().InsertChar('x')
+
+	cmd := m.execCommand("Quit")
+	if cmd != nil {
+		t.Errorf("execCommand(\"Quit\") with dirty buffer should return nil cmd, got %T", cmd())
+	}
+	if !m.confirm.Active() {
+		t.Error("execCommand(\"Quit\") did not open the dialog")
+	}
+}
+
+// ---- helpers ----
+
+func mustWriteTemp(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "grotto-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	return filepath.Clean(f.Name())
+}
+
+// keyFromString builds a KeyPressMsg for a logical key string like "ctrl+q",
+// "enter", "s", or "esc". Single-character inputs become plain rune keys.
+func keyFromString(s string) tea.KeyPressMsg {
+	switch s {
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEscape}
+	case "ctrl+q":
+		return tea.KeyPressMsg{Code: 'q', Mod: tea.ModCtrl}
+	}
+	if len(s) == 1 {
+		return tea.KeyPressMsg{Code: rune(s[0]), Text: s}
+	}
+	// Fallback: single rune of first char.
+	return tea.KeyPressMsg{Code: rune(s[0]), Text: s[:1]}
+}
+

--- a/app/confirm_test.go
+++ b/app/confirm_test.go
@@ -268,4 +268,3 @@ func keyFromString(s string) tea.KeyPressMsg {
 	// Fallback: single rune of first char.
 	return tea.KeyPressMsg{Code: rune(s[0]), Text: s[:1]}
 }
-

--- a/editor/panes.go
+++ b/editor/panes.go
@@ -373,6 +373,37 @@ func (pm PaneManager) HasSearchActive() bool {
 	return pm.panes[pm.active].search.Active()
 }
 
+// DirtyBuffers returns the unique set of buffers with unsaved changes across
+// all panes (buffers may be shared between panes — they're de-duped here).
+func (pm PaneManager) DirtyBuffers() []*Buffer {
+	seen := make(map[*Buffer]struct{})
+	var out []*Buffer
+	for i := range pm.panes {
+		for _, t := range pm.panes[i].tabs {
+			if t.buf == nil || !t.buf.Dirty {
+				continue
+			}
+			if _, ok := seen[t.buf]; ok {
+				continue
+			}
+			seen[t.buf] = struct{}{}
+			out = append(out, t.buf)
+		}
+	}
+	return out
+}
+
+// SaveAllDirty persists every dirty buffer. Returns the first error encountered,
+// or nil if all saves succeeded.
+func (pm PaneManager) SaveAllDirty() error {
+	for _, b := range pm.DirtyBuffers() {
+		if err := b.Save(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // TabInfo returns a summary string for the status bar.
 func (pm PaneManager) TabInfo() string {
 	if len(pm.panes) <= 1 {

--- a/editor/panes_test.go
+++ b/editor/panes_test.go
@@ -1,0 +1,108 @@
+package editor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// DirtyBuffers returns only dirty buffers, de-duplicated across panes.
+func TestPaneManager_DirtyBuffers(t *testing.T) {
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a.txt", "alpha\n")
+	b := writeFile(t, dir, "b.txt", "bravo\n")
+
+	pm := NewPaneManager()
+	// Open two files in pane 0.
+	mustOpen(t, &pm, a)
+	mustOpen(t, &pm, b)
+
+	if got := pm.DirtyBuffers(); len(got) != 0 {
+		t.Errorf("fresh open: DirtyBuffers = %d, want 0", len(got))
+	}
+
+	// Mutate only `a`.
+	findBuf(t, &pm, a).InsertChar('x')
+
+	dirty := pm.DirtyBuffers()
+	if len(dirty) != 1 {
+		t.Fatalf("after mutating a: DirtyBuffers = %d, want 1", len(dirty))
+	}
+	if dirty[0].FilePath != a {
+		t.Errorf("dirty buffer path: got %q, want %q", dirty[0].FilePath, a)
+	}
+
+	// Split — shared buffer for `b` appears in two panes. Mutate from either;
+	// it must appear only once in DirtyBuffers.
+	pm.Split(SplitRight)
+	findBuf(t, &pm, b).InsertChar('y')
+
+	dirty = pm.DirtyBuffers()
+	if len(dirty) != 2 {
+		t.Fatalf("after mutating b in split: DirtyBuffers = %d, want 2", len(dirty))
+	}
+	paths := map[string]bool{dirty[0].FilePath: true, dirty[1].FilePath: true}
+	if !paths[a] || !paths[b] {
+		t.Errorf("dirty paths: got %v, want both a.txt and b.txt", paths)
+	}
+}
+
+// SaveAllDirty writes every dirty buffer to disk and clears the dirty flag.
+func TestPaneManager_SaveAllDirty(t *testing.T) {
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a.txt", "alpha\n")
+	b := writeFile(t, dir, "b.txt", "bravo\n")
+
+	pm := NewPaneManager()
+	mustOpen(t, &pm, a)
+	mustOpen(t, &pm, b)
+	findBuf(t, &pm, a).InsertChar('X')
+	findBuf(t, &pm, b).InsertChar('Y')
+
+	if err := pm.SaveAllDirty(); err != nil {
+		t.Fatalf("SaveAllDirty: %v", err)
+	}
+
+	if got := pm.DirtyBuffers(); len(got) != 0 {
+		t.Errorf("after SaveAllDirty: DirtyBuffers = %d, want 0", len(got))
+	}
+
+	// Verify on disk.
+	if data, _ := os.ReadFile(a); string(data) != "Xalpha\n" {
+		t.Errorf("file a: got %q, want %q", string(data), "Xalpha\n")
+	}
+	if data, _ := os.ReadFile(b); string(data) != "Ybravo\n" {
+		t.Errorf("file b: got %q, want %q", string(data), "Ybravo\n")
+	}
+}
+
+// ---- helpers ----
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return p
+}
+
+func mustOpen(t *testing.T, pm *PaneManager, path string) {
+	t.Helper()
+	if err := pm.OpenFile(path); err != nil {
+		t.Fatalf("OpenFile(%s): %v", path, err)
+	}
+}
+
+func findBuf(t *testing.T, pm *PaneManager, path string) *Buffer {
+	t.Helper()
+	for i := range pm.panes {
+		for _, tab := range pm.panes[i].tabs {
+			if tab.buf != nil && tab.buf.FilePath == path {
+				return tab.buf
+			}
+		}
+	}
+	t.Fatalf("no buffer for path %q", path)
+	return nil
+}


### PR DESCRIPTION
## Summary

Pressing `Ctrl+Q` (or selecting **Quit** in the command palette) while any open buffer has unsaved edits now opens a modal dialog listing the dirty files:

- **[S]ave** — save all dirty buffers, then quit
- **[D]iscard** — quit without saving
- **[C]ancel** (or `Esc`) — dismiss the dialog

`Enter` defaults to Save (least destructive). Other keys are consumed while the modal is up so they don't leak to the editor or sidebar.

Clean quits (no dirty buffers) skip the dialog entirely — Ctrl+Q still exits immediately when there's nothing to lose.

## Scope note

Ctrl+W (close tab) and middle-click-close still lose unsaved work. That path will get the same dialog in a follow-up — left out of this PR to keep the diff focused.

## New code

| File | What |
|------|------|
| `app/confirm.go` | `ConfirmDialog` type — self-contained modal |
| `editor/panes.go` | `DirtyBuffers()` / `SaveAllDirty()` — de-dupe buffers shared across split panes |
| `app/confirm_test.go` | 11 tests |
| `editor/panes_test.go` | 2 tests |

## Test plan

- [x] 13 new unit tests covering:
  - Dialog key handling (s/S/d/D/c/C/enter/esc)
  - Input swallowed while modal is up (doesn't leak to editor)
  - Ctrl+Q on clean editor → quits immediately
  - Ctrl+Q with dirty buffer → opens dialog (no quit)
  - `Save` → persists file, clears dirty flag, quits
  - `Discard` → quits without saving, leaves buffer dirty
  - `Cancel` → closes dialog, no quit, buffer still dirty
  - Command palette "Quit" path respects dirty check
  - `DirtyBuffers` de-dupes across panes sharing a buffer
  - `SaveAllDirty` persists every dirty buffer
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `go build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)