### PR TITLE
feat: built-in named themes + live theme switching

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -966,7 +966,7 @@ func (m Model) bdr(p FocusedPanel) lipgloss.Style {
 }
 
 func (m Model) commandNames() []string {
-	return []string{
+	names := []string{
 		"Toggle Sidebar",
 		"Toggle Terminal",
 		"Toggle AI Panel",
@@ -977,8 +977,12 @@ func (m Model) commandNames() []string {
 		"Split Right",
 		"Split Down",
 		"Close Pane",
-		"Quit",
 	}
+	for _, t := range config.BuiltInThemeNames() {
+		names = append(names, "Theme: "+t)
+	}
+	names = append(names, "Quit")
+	return names
 }
 
 func (m *Model) execCommand(name string) tea.Cmd {
@@ -1012,6 +1016,27 @@ func (m *Model) execCommand(name string) tea.Cmd {
 		m.recalcLayout()
 		m.updateFocus()
 		return m.aiPanel.AddTermWithCmd(provider, m.aiCommand())
+	default:
+		if strings.HasPrefix(name, "Theme: ") {
+			m.applyNamedTheme(strings.TrimPrefix(name, "Theme: "))
+			return nil
+		}
 	}
 	return nil
+}
+
+// applyNamedTheme swaps the active theme across all packages and invalidates
+// cached render output so the next frame reflects the new colors.
+func (m *Model) applyNamedTheme(themeName string) {
+	theme, ok := config.ThemeByName(themeName)
+	if !ok {
+		return
+	}
+	applyTheme(theme)
+	editor.ApplyTheme(theme)
+	ui.ApplyTheme(theme)
+	m.dirtyPanels = dirtyAll
+	m.cachedSidebar = ""
+	m.cachedTerminal = ""
+	m.cachedAI = ""
 }

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/owomeister/grotto/config"
+)
+
+// Command palette must list every built-in theme plus Quit / AI commands.
+func TestCommandNames_IncludesAllBuiltInThemes(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	names := m.commandNames()
+
+	seen := map[string]bool{}
+	for _, n := range names {
+		seen[n] = true
+	}
+
+	for _, tname := range config.BuiltInThemeNames() {
+		entry := "Theme: " + tname
+		if !seen[entry] {
+			t.Errorf("command palette missing %q", entry)
+		}
+	}
+	if !seen["Quit"] {
+		t.Error("command palette missing \"Quit\"")
+	}
+}
+
+// Theme entries follow the "Theme: <name>" format that execCommand parses.
+func TestCommandNames_ThemeEntryFormat(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	for _, n := range m.commandNames() {
+		if !strings.HasPrefix(n, "Theme: ") {
+			continue
+		}
+		tname := strings.TrimPrefix(n, "Theme: ")
+		if _, ok := config.ThemeByName(tname); !ok {
+			t.Errorf("command %q references unknown theme %q", n, tname)
+		}
+	}
+}
+
+// Selecting a theme via the command palette routes through applyNamedTheme.
+// We can't easily assert the lipgloss styles changed without reflection,
+// but we can verify execCommand accepts "Theme: nord" without error and
+// returns nil (no cmd is needed — theme switch is purely side-effecting).
+func TestExecCommand_ThemeSwitch(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	// Mark panels clean so we can detect that the switch dirties them.
+	m.dirtyPanels = 0
+	m.cachedSidebar = "cached-sidebar"
+	m.cachedTerminal = "cached-terminal"
+	m.cachedAI = "cached-ai"
+
+	cmd := m.execCommand("Theme: nord")
+	if cmd != nil {
+		t.Errorf("execCommand(\"Theme: nord\") returned non-nil cmd %T", cmd())
+	}
+	if m.dirtyPanels != dirtyAll {
+		t.Errorf("dirtyPanels: got %#x, want dirtyAll (%#x)", m.dirtyPanels, dirtyAll)
+	}
+	if m.cachedSidebar != "" || m.cachedTerminal != "" || m.cachedAI != "" {
+		t.Error("theme switch did not invalidate cached panel renders")
+	}
+}
+
+// Unknown themes are ignored silently — they shouldn't crash or mark panels dirty.
+func TestExecCommand_ThemeSwitch_Unknown(t *testing.T) {
+	m := New(Config{Path: "/home/nishchay/grotto", NoAI: true})
+	m.dirtyPanels = 0
+	m.cachedSidebar = "preserved"
+
+	cmd := m.execCommand("Theme: not-real")
+	if cmd != nil {
+		t.Error("unknown theme returned non-nil cmd")
+	}
+	if m.dirtyPanels != 0 {
+		t.Error("unknown theme marked panels dirty")
+	}
+	if m.cachedSidebar != "preserved" {
+		t.Error("unknown theme cleared cached sidebar")
+	}
+}

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,13 @@
 # Grotto configuration — copy to ~/.config/grotto/config.toml to customize.
 # All color values are hex strings. Missing keys fall back to the built-in defaults.
 
+# Pick a built-in theme by name. Leave unset (or empty) for "dracula".
+# Available: dracula, nord, solarized-dark, solarized-light, gruvbox-dark, tokyonight
+# You can also switch themes at runtime via the command palette (Ctrl+Shift+P / F2).
+# theme_name = "nord"
+
+# Per-field overrides layer on top of whichever theme is selected above,
+# so you can pick `nord` and still recolor, say, the title bar.
 [theme]
 
 # ── App chrome ──────────────────────────────────────────────────────────────

--- a/config/config.go
+++ b/config/config.go
@@ -59,62 +59,27 @@ type Theme struct {
 
 // Config is the top-level configuration structure.
 type Config struct {
-	Theme Theme `toml:"theme"`
+	// ThemeName selects a built-in theme by its identifier (e.g. "nord",
+	// "solarized-dark"). If empty, defaults to "dracula". Per-field overrides
+	// in the [theme] table are applied on top of the selected base.
+	ThemeName string `toml:"theme_name"`
+	Theme     Theme  `toml:"theme"`
 }
 
-// DefaultTheme returns the built-in Dracula-inspired theme.
+// DefaultTheme returns the built-in Dracula theme — grotto's default look.
+// Callers wanting a specific named theme should use ThemeByName instead.
 func DefaultTheme() Theme {
-	return Theme{
-		// App chrome
-		TitleBg:      "#7D56F4",
-		TitleFg:      "#FAFAFA",
-		BtnBg:        "#5A3EC8",
-		BtnFg:        "#FAFAFA",
-		BtnActiveBg:  "#FAFAFA",
-		BtnActiveFg:  "#5A3EC8",
-		StatusBg:     "#3C3C3C",
-		StatusFg:     "#AAAAAA",
-		BorderDim:    "#555555",
-		BorderHover:  "#A98AFF",
-		BorderActive: "#7D56F4",
-
-		// Editor
-		GutterFg:    "#555555",
-		CurLineBg:   "#2A2A2A",
-		TabBarBg:    "#21222C",
-		TabFg:       "#888888",
-		TabActiveFg: "#FFFFFF",
-		TabActiveBg: "#44475a",
-		SelectionBg: "#44475a",
-		BracketHLBg: "#44475a",
-
-		// Search overlay
-		SearchOverlayBg:     "#282A36",
-		SearchOverlayFg:     "#F8F8F2",
-		SearchInputBg:       "#44475A",
-		SearchInputFg:       "#F8F8F2",
-		SearchMatchBg:       "#FFB86C",
-		SearchMatchFg:       "#282A36",
-		SearchActiveMatchBg: "#FF79C6",
-		SearchActiveMatchFg: "#282A36",
-		SearchLabelFg:       "#6272A4",
-
-		// Sidebar
-		SidebarSelectedBg: "#7D56F4",
-		SidebarSelectedFg: "#FAFAFA",
-		SidebarDirIcon:    "#89DDFF",
-
-		// Git status
-		GitAdded:     "#50FA7B",
-		GitModified:  "#E5C07B",
-		GitDeleted:   "#E06C75",
-		GitRenamed:   "#61AFEF",
-		GitUntracked: "#A9DC76",
-	}
+	return DraculaTheme()
 }
 
 // Load reads ~/.config/grotto/config.toml if it exists, fills any missing
 // fields with defaults, and returns the result.
+//
+// Resolution order for theme colors:
+//  1. Start with Dracula as the baseline.
+//  2. If `theme_name = "..."` is set and names a built-in theme, use that as
+//     the baseline instead.
+//  3. Apply any per-field overrides from the [theme] table on top.
 func Load() Config {
 	cfg := Config{Theme: DefaultTheme()}
 
@@ -128,11 +93,19 @@ func Load() Config {
 		return cfg // file doesn't exist — use defaults silently
 	}
 
-	// Decode into a partial struct; only present keys override defaults.
 	var partial Config
 	if _, err := toml.Decode(string(data), &partial); err != nil {
 		return cfg // malformed TOML — use defaults silently
 	}
+
+	if partial.ThemeName != "" {
+		if base, ok := ThemeByName(partial.ThemeName); ok {
+			cfg.Theme = base
+			cfg.ThemeName = partial.ThemeName
+		}
+	}
+
+	// Per-field overrides layer on top of the selected base.
 	mergeTheme(&cfg.Theme, partial.Theme)
 	return cfg
 }

--- a/config/themes.go
+++ b/config/themes.go
@@ -1,0 +1,317 @@
+package config
+
+import "strings"
+
+// BuiltInThemes returns the palette of named themes shipped with grotto.
+// The map key is the lowercase identifier used in `theme = "..."` config and
+// in the command palette ("Theme: Nord" → "nord").
+func BuiltInThemes() map[string]Theme {
+	return map[string]Theme{
+		"dracula":         DraculaTheme(),
+		"nord":            NordTheme(),
+		"solarized-dark":  SolarizedDarkTheme(),
+		"solarized-light": SolarizedLightTheme(),
+		"gruvbox-dark":    GruvboxDarkTheme(),
+		"tokyonight":      TokyoNightTheme(),
+	}
+}
+
+// BuiltInThemeNames returns the stable sorted list of theme identifiers
+// for display in UI (command palette, docs, etc.).
+func BuiltInThemeNames() []string {
+	return []string{
+		"dracula",
+		"nord",
+		"solarized-dark",
+		"solarized-light",
+		"gruvbox-dark",
+		"tokyonight",
+	}
+}
+
+// ThemeByName returns the theme with the given name and whether it was found.
+// Matching is case-insensitive.
+func ThemeByName(name string) (Theme, bool) {
+	t, ok := BuiltInThemes()[strings.ToLower(name)]
+	return t, ok
+}
+
+// DraculaTheme is grotto's default theme — dark, purple-forward.
+func DraculaTheme() Theme {
+	return Theme{
+		TitleBg:      "#7D56F4",
+		TitleFg:      "#FAFAFA",
+		BtnBg:        "#5A3EC8",
+		BtnFg:        "#FAFAFA",
+		BtnActiveBg:  "#FAFAFA",
+		BtnActiveFg:  "#5A3EC8",
+		StatusBg:     "#3C3C3C",
+		StatusFg:     "#AAAAAA",
+		BorderDim:    "#555555",
+		BorderHover:  "#A98AFF",
+		BorderActive: "#7D56F4",
+
+		GutterFg:    "#555555",
+		CurLineBg:   "#2A2A2A",
+		TabBarBg:    "#21222C",
+		TabFg:       "#888888",
+		TabActiveFg: "#FFFFFF",
+		TabActiveBg: "#44475a",
+		SelectionBg: "#44475a",
+		BracketHLBg: "#44475a",
+
+		SearchOverlayBg:     "#282A36",
+		SearchOverlayFg:     "#F8F8F2",
+		SearchInputBg:       "#44475A",
+		SearchInputFg:       "#F8F8F2",
+		SearchMatchBg:       "#FFB86C",
+		SearchMatchFg:       "#282A36",
+		SearchActiveMatchBg: "#FF79C6",
+		SearchActiveMatchFg: "#282A36",
+		SearchLabelFg:       "#6272A4",
+
+		SidebarSelectedBg: "#7D56F4",
+		SidebarSelectedFg: "#FAFAFA",
+		SidebarDirIcon:    "#89DDFF",
+
+		GitAdded:     "#50FA7B",
+		GitModified:  "#E5C07B",
+		GitDeleted:   "#E06C75",
+		GitRenamed:   "#61AFEF",
+		GitUntracked: "#A9DC76",
+	}
+}
+
+// NordTheme is the Nord palette (arctic, muted blues).
+// https://www.nordtheme.com
+func NordTheme() Theme {
+	return Theme{
+		TitleBg:      "#5E81AC",
+		TitleFg:      "#ECEFF4",
+		BtnBg:        "#4C566A",
+		BtnFg:        "#ECEFF4",
+		BtnActiveBg:  "#88C0D0",
+		BtnActiveFg:  "#2E3440",
+		StatusBg:     "#3B4252",
+		StatusFg:     "#D8DEE9",
+		BorderDim:    "#4C566A",
+		BorderHover:  "#81A1C1",
+		BorderActive: "#88C0D0",
+
+		GutterFg:    "#4C566A",
+		CurLineBg:   "#3B4252",
+		TabBarBg:    "#2E3440",
+		TabFg:       "#81A1C1",
+		TabActiveFg: "#ECEFF4",
+		TabActiveBg: "#434C5E",
+		SelectionBg: "#434C5E",
+		BracketHLBg: "#4C566A",
+
+		SearchOverlayBg:     "#2E3440",
+		SearchOverlayFg:     "#ECEFF4",
+		SearchInputBg:       "#3B4252",
+		SearchInputFg:       "#ECEFF4",
+		SearchMatchBg:       "#EBCB8B",
+		SearchMatchFg:       "#2E3440",
+		SearchActiveMatchBg: "#D08770",
+		SearchActiveMatchFg: "#2E3440",
+		SearchLabelFg:       "#81A1C1",
+
+		SidebarSelectedBg: "#5E81AC",
+		SidebarSelectedFg: "#ECEFF4",
+		SidebarDirIcon:    "#88C0D0",
+
+		GitAdded:     "#A3BE8C",
+		GitModified:  "#EBCB8B",
+		GitDeleted:   "#BF616A",
+		GitRenamed:   "#81A1C1",
+		GitUntracked: "#8FBCBB",
+	}
+}
+
+// SolarizedDarkTheme — Ethan Schoonover's Solarized (dark variant).
+// https://ethanschoonover.com/solarized
+func SolarizedDarkTheme() Theme {
+	return Theme{
+		TitleBg:      "#268BD2",
+		TitleFg:      "#FDF6E3",
+		BtnBg:        "#073642",
+		BtnFg:        "#93A1A1",
+		BtnActiveBg:  "#93A1A1",
+		BtnActiveFg:  "#002B36",
+		StatusBg:     "#073642",
+		StatusFg:     "#93A1A1",
+		BorderDim:    "#586E75",
+		BorderHover:  "#2AA198",
+		BorderActive: "#268BD2",
+
+		GutterFg:    "#586E75",
+		CurLineBg:   "#073642",
+		TabBarBg:    "#002B36",
+		TabFg:       "#586E75",
+		TabActiveFg: "#FDF6E3",
+		TabActiveBg: "#073642",
+		SelectionBg: "#073642",
+		BracketHLBg: "#073642",
+
+		SearchOverlayBg:     "#002B36",
+		SearchOverlayFg:     "#FDF6E3",
+		SearchInputBg:       "#073642",
+		SearchInputFg:       "#FDF6E3",
+		SearchMatchBg:       "#B58900",
+		SearchMatchFg:       "#002B36",
+		SearchActiveMatchBg: "#CB4B16",
+		SearchActiveMatchFg: "#FDF6E3",
+		SearchLabelFg:       "#586E75",
+
+		SidebarSelectedBg: "#268BD2",
+		SidebarSelectedFg: "#FDF6E3",
+		SidebarDirIcon:    "#2AA198",
+
+		GitAdded:     "#859900",
+		GitModified:  "#B58900",
+		GitDeleted:   "#DC322F",
+		GitRenamed:   "#6C71C4",
+		GitUntracked: "#2AA198",
+	}
+}
+
+// SolarizedLightTheme — light variant of Solarized.
+func SolarizedLightTheme() Theme {
+	return Theme{
+		TitleBg:      "#268BD2",
+		TitleFg:      "#FDF6E3",
+		BtnBg:        "#EEE8D5",
+		BtnFg:        "#586E75",
+		BtnActiveBg:  "#586E75",
+		BtnActiveFg:  "#FDF6E3",
+		StatusBg:     "#EEE8D5",
+		StatusFg:     "#586E75",
+		BorderDim:    "#93A1A1",
+		BorderHover:  "#2AA198",
+		BorderActive: "#268BD2",
+
+		GutterFg:    "#93A1A1",
+		CurLineBg:   "#EEE8D5",
+		TabBarBg:    "#FDF6E3",
+		TabFg:       "#93A1A1",
+		TabActiveFg: "#002B36",
+		TabActiveBg: "#EEE8D5",
+		SelectionBg: "#EEE8D5",
+		BracketHLBg: "#EEE8D5",
+
+		SearchOverlayBg:     "#FDF6E3",
+		SearchOverlayFg:     "#002B36",
+		SearchInputBg:       "#EEE8D5",
+		SearchInputFg:       "#002B36",
+		SearchMatchBg:       "#B58900",
+		SearchMatchFg:       "#FDF6E3",
+		SearchActiveMatchBg: "#CB4B16",
+		SearchActiveMatchFg: "#FDF6E3",
+		SearchLabelFg:       "#93A1A1",
+
+		SidebarSelectedBg: "#268BD2",
+		SidebarSelectedFg: "#FDF6E3",
+		SidebarDirIcon:    "#2AA198",
+
+		GitAdded:     "#859900",
+		GitModified:  "#B58900",
+		GitDeleted:   "#DC322F",
+		GitRenamed:   "#6C71C4",
+		GitUntracked: "#2AA198",
+	}
+}
+
+// GruvboxDarkTheme — warm retro palette.
+// https://github.com/morhetz/gruvbox
+func GruvboxDarkTheme() Theme {
+	return Theme{
+		TitleBg:      "#D79921",
+		TitleFg:      "#282828",
+		BtnBg:        "#3C3836",
+		BtnFg:        "#EBDBB2",
+		BtnActiveBg:  "#FABD2F",
+		BtnActiveFg:  "#282828",
+		StatusBg:     "#3C3836",
+		StatusFg:     "#A89984",
+		BorderDim:    "#504945",
+		BorderHover:  "#FABD2F",
+		BorderActive: "#D79921",
+
+		GutterFg:    "#504945",
+		CurLineBg:   "#3C3836",
+		TabBarBg:    "#1D2021",
+		TabFg:       "#928374",
+		TabActiveFg: "#FBF1C7",
+		TabActiveBg: "#3C3836",
+		SelectionBg: "#504945",
+		BracketHLBg: "#504945",
+
+		SearchOverlayBg:     "#282828",
+		SearchOverlayFg:     "#EBDBB2",
+		SearchInputBg:       "#3C3836",
+		SearchInputFg:       "#EBDBB2",
+		SearchMatchBg:       "#FABD2F",
+		SearchMatchFg:       "#282828",
+		SearchActiveMatchBg: "#FE8019",
+		SearchActiveMatchFg: "#282828",
+		SearchLabelFg:       "#928374",
+
+		SidebarSelectedBg: "#D79921",
+		SidebarSelectedFg: "#282828",
+		SidebarDirIcon:    "#83A598",
+
+		GitAdded:     "#B8BB26",
+		GitModified:  "#FABD2F",
+		GitDeleted:   "#FB4934",
+		GitRenamed:   "#83A598",
+		GitUntracked: "#8EC07C",
+	}
+}
+
+// TokyoNightTheme — Tokyo Night (dark) palette.
+// https://github.com/enkia/tokyo-night-vscode-theme
+func TokyoNightTheme() Theme {
+	return Theme{
+		TitleBg:      "#7AA2F7",
+		TitleFg:      "#1A1B26",
+		BtnBg:        "#24283B",
+		BtnFg:        "#C0CAF5",
+		BtnActiveBg:  "#BB9AF7",
+		BtnActiveFg:  "#1A1B26",
+		StatusBg:     "#16161E",
+		StatusFg:     "#A9B1D6",
+		BorderDim:    "#414868",
+		BorderHover:  "#7AA2F7",
+		BorderActive: "#BB9AF7",
+
+		GutterFg:    "#3B4261",
+		CurLineBg:   "#24283B",
+		TabBarBg:    "#16161E",
+		TabFg:       "#565F89",
+		TabActiveFg: "#C0CAF5",
+		TabActiveBg: "#1A1B26",
+		SelectionBg: "#283457",
+		BracketHLBg: "#364A82",
+
+		SearchOverlayBg:     "#1A1B26",
+		SearchOverlayFg:     "#C0CAF5",
+		SearchInputBg:       "#24283B",
+		SearchInputFg:       "#C0CAF5",
+		SearchMatchBg:       "#E0AF68",
+		SearchMatchFg:       "#1A1B26",
+		SearchActiveMatchBg: "#F7768E",
+		SearchActiveMatchFg: "#1A1B26",
+		SearchLabelFg:       "#565F89",
+
+		SidebarSelectedBg: "#7AA2F7",
+		SidebarSelectedFg: "#1A1B26",
+		SidebarDirIcon:    "#7DCFFF",
+
+		GitAdded:     "#9ECE6A",
+		GitModified:  "#E0AF68",
+		GitDeleted:   "#F7768E",
+		GitRenamed:   "#7AA2F7",
+		GitUntracked: "#73DACA",
+	}
+}

--- a/config/themes_test.go
+++ b/config/themes_test.go
@@ -1,0 +1,196 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+var hexColor = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+
+// Every field of every built-in theme must be a valid 6-char hex color.
+// Missing fields would surface as empty strings that crash the lipgloss
+// renderer; this catches typos and forgotten fields at compile-time.
+func TestBuiltInThemes_AllFieldsPopulated(t *testing.T) {
+	themes := BuiltInThemes()
+	if len(themes) == 0 {
+		t.Fatal("BuiltInThemes returned empty map")
+	}
+	for name, theme := range themes {
+		t.Run(name, func(t *testing.T) {
+			checkField(t, "TitleBg", theme.TitleBg)
+			checkField(t, "TitleFg", theme.TitleFg)
+			checkField(t, "BtnBg", theme.BtnBg)
+			checkField(t, "BtnFg", theme.BtnFg)
+			checkField(t, "BtnActiveBg", theme.BtnActiveBg)
+			checkField(t, "BtnActiveFg", theme.BtnActiveFg)
+			checkField(t, "StatusBg", theme.StatusBg)
+			checkField(t, "StatusFg", theme.StatusFg)
+			checkField(t, "BorderDim", theme.BorderDim)
+			checkField(t, "BorderHover", theme.BorderHover)
+			checkField(t, "BorderActive", theme.BorderActive)
+			checkField(t, "GutterFg", theme.GutterFg)
+			checkField(t, "CurLineBg", theme.CurLineBg)
+			checkField(t, "TabBarBg", theme.TabBarBg)
+			checkField(t, "TabFg", theme.TabFg)
+			checkField(t, "TabActiveFg", theme.TabActiveFg)
+			checkField(t, "TabActiveBg", theme.TabActiveBg)
+			checkField(t, "SelectionBg", theme.SelectionBg)
+			checkField(t, "BracketHLBg", theme.BracketHLBg)
+			checkField(t, "SearchOverlayBg", theme.SearchOverlayBg)
+			checkField(t, "SearchOverlayFg", theme.SearchOverlayFg)
+			checkField(t, "SearchInputBg", theme.SearchInputBg)
+			checkField(t, "SearchInputFg", theme.SearchInputFg)
+			checkField(t, "SearchMatchBg", theme.SearchMatchBg)
+			checkField(t, "SearchMatchFg", theme.SearchMatchFg)
+			checkField(t, "SearchActiveMatchBg", theme.SearchActiveMatchBg)
+			checkField(t, "SearchActiveMatchFg", theme.SearchActiveMatchFg)
+			checkField(t, "SearchLabelFg", theme.SearchLabelFg)
+			checkField(t, "SidebarSelectedBg", theme.SidebarSelectedBg)
+			checkField(t, "SidebarSelectedFg", theme.SidebarSelectedFg)
+			checkField(t, "SidebarDirIcon", theme.SidebarDirIcon)
+			checkField(t, "GitAdded", theme.GitAdded)
+			checkField(t, "GitModified", theme.GitModified)
+			checkField(t, "GitDeleted", theme.GitDeleted)
+			checkField(t, "GitRenamed", theme.GitRenamed)
+			checkField(t, "GitUntracked", theme.GitUntracked)
+		})
+	}
+}
+
+// BuiltInThemeNames must return exactly the keys of BuiltInThemes so the
+// command palette and the resolver stay in sync.
+func TestBuiltInThemeNames_MatchesMap(t *testing.T) {
+	names := BuiltInThemeNames()
+	themes := BuiltInThemes()
+	if len(names) != len(themes) {
+		t.Errorf("names=%d themes=%d — out of sync", len(names), len(themes))
+	}
+	for _, n := range names {
+		if _, ok := themes[n]; !ok {
+			t.Errorf("BuiltInThemeNames lists %q but BuiltInThemes has no such key", n)
+		}
+	}
+}
+
+func TestThemeByName_CaseInsensitive(t *testing.T) {
+	cases := []string{"nord", "NORD", "Nord", "nOrD"}
+	for _, c := range cases {
+		if _, ok := ThemeByName(c); !ok {
+			t.Errorf("ThemeByName(%q): not found", c)
+		}
+	}
+}
+
+func TestThemeByName_Unknown(t *testing.T) {
+	if _, ok := ThemeByName("does-not-exist"); ok {
+		t.Error("ThemeByName returned ok=true for unknown theme")
+	}
+}
+
+// Dracula remains the default — catches accidental swaps.
+func TestDefaultTheme_IsDracula(t *testing.T) {
+	if DefaultTheme() != DraculaTheme() {
+		t.Error("DefaultTheme() no longer returns DraculaTheme()")
+	}
+}
+
+// Load honors theme_name, applies built-in, lets [theme] override on top.
+func TestLoad_ThemeNameSelectsBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	// Point HOME at a temp dir so configPath resolves there.
+	t.Setenv("HOME", dir)
+	cfgDir := filepath.Join(dir, ".config", "grotto")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	tomlBody := `theme_name = "nord"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(tomlBody), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := Load()
+	if cfg.ThemeName != "nord" {
+		t.Errorf("ThemeName: got %q, want %q", cfg.ThemeName, "nord")
+	}
+	if cfg.Theme.TitleBg != NordTheme().TitleBg {
+		t.Errorf("TitleBg: got %q, want Nord's %q", cfg.Theme.TitleBg, NordTheme().TitleBg)
+	}
+}
+
+func TestLoad_PerFieldOverrideOnTopOfNamedTheme(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgDir := filepath.Join(dir, ".config", "grotto")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Pick Nord as base, but recolor only the title bar.
+	tomlBody := `theme_name = "nord"
+
+[theme]
+title_bg = "#FF00FF"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(tomlBody), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := Load()
+	if cfg.Theme.TitleBg != "#FF00FF" {
+		t.Errorf("title_bg override ignored: got %q, want %q", cfg.Theme.TitleBg, "#FF00FF")
+	}
+	// Other Nord fields should remain intact.
+	if cfg.Theme.TitleFg != NordTheme().TitleFg {
+		t.Errorf("title_fg: got %q, want Nord's %q (override should only affect title_bg)",
+			cfg.Theme.TitleFg, NordTheme().TitleFg)
+	}
+}
+
+func TestLoad_UnknownThemeNameFallsBackToDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgDir := filepath.Join(dir, ".config", "grotto")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	tomlBody := `theme_name = "not-a-real-theme"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(tomlBody), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := Load()
+	// Falls back to Dracula silently. ThemeName stays empty to signal the
+	// config value was not applied.
+	if cfg.ThemeName != "" {
+		t.Errorf("ThemeName: got %q, want empty on unknown", cfg.ThemeName)
+	}
+	if cfg.Theme != DraculaTheme() {
+		t.Error("expected Dracula fallback when theme_name is unknown")
+	}
+}
+
+func TestLoad_NoConfigUsesDracula(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// No config file written.
+	cfg := Load()
+	if cfg.Theme != DraculaTheme() {
+		t.Error("no config file should yield Dracula theme")
+	}
+}
+
+func checkField(t *testing.T, name, value string) {
+	t.Helper()
+	if value == "" {
+		t.Errorf("%s is empty", name)
+		return
+	}
+	if !hexColor.MatchString(value) {
+		t.Errorf("%s = %q is not a 6-char hex color like #RRGGBB", name, value)
+	}
+}


### PR DESCRIPTION
## Summary

Adds 6 built-in themes, selectable by name via config or the command palette:

| Theme | Vibe |
|-------|------|
| `dracula` (default) | Dark, purple-forward |
| `nord` | Arctic, muted blues |
| `solarized-dark` | Ethan Schoonover's Solarized |
| `solarized-light` | Light variant |
| `gruvbox-dark` | Warm retro |
| `tokyonight` | Tokyo Night (VS Code-inspired) |

## Two ways to pick a theme

**Config file** — `~/.config/grotto/config.toml`:

```toml
theme_name = "nord"
```

**Runtime** — command palette (Ctrl+Shift+P or F2):

```
Theme: nord
Theme: tokyonight
Theme: gruvbox-dark
...
```

Live-switching invalidates all cached panel renders so the new colors paint on the next frame.

## Per-field overrides still work

The existing `[theme]` table layers on top of whichever base was selected:

```toml
theme_name = "nord"

[theme]
title_bg = "#FF00FF"   # use Nord but hot-pink the title bar
```

Resolution order: Dracula → named base (if `theme_name` set) → per-field overrides.

## What's in the PR

| File | What |
|------|------|
| `config/themes.go` | 6 palette definitions + `ThemeByName`, `BuiltInThemes`, `BuiltInThemeNames` |
| `config/config.go` | New `theme_name` top-level TOML key; resolution pipeline |
| `app/app.go` | "Theme: `<name>`" entries in palette; `applyNamedTheme` swaps styles + busts render cache |
| `config.toml.example` | Documents the new option |

## Test plan

- [x] 9 tests in `config/themes_test.go`:
  - Every field of every built-in theme is a valid `#RRGGBB` hex color
  - `BuiltInThemeNames` stays in sync with the map
  - `ThemeByName` is case-insensitive
  - `Load()` honors `theme_name` and switches base
  - Per-field overrides layer on top of named base
  - Unknown `theme_name` falls back silently to Dracula
  - No config file uses Dracula
- [x] 4 tests in `app/themes_test.go`:
  - Command palette includes every built-in theme entry
  - Every "Theme: X" entry resolves to a real theme
  - `execCommand("Theme: nord")` invalidates render caches
  - Unknown theme names are no-ops (no cache invalidation, no crash)
- [x] Visually verified end-to-end: ran grotto with `theme_name = "nord"`, confirmed Nord-blue (`#5E81AC`) title bar via GIF frame + pixel inspection
- [x] `go test -race ./...` green
- [x] `gofmt -l .` clean, `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)